### PR TITLE
Native: VibratorFeature: Import Xiaomi Android 13 Changes

### DIFF
--- a/services/vibratorservice/Android.bp
+++ b/services/vibratorservice/Android.bp
@@ -45,6 +45,7 @@ cc_library_shared {
         "libhidlbase",
         "liblog",
         "libutils",
+        "libcutils",
         "android.hardware.vibrator-V2-cpp",
         "android.hardware.vibrator@1.0",
         "android.hardware.vibrator@1.1",

--- a/services/vibratorservice/VibratorHalController.cpp
+++ b/services/vibratorservice/VibratorHalController.cpp
@@ -53,7 +53,16 @@ std::shared_ptr<HalWrapper> connectHal(std::shared_ptr<CallbackScheduler> schedu
         return nullptr;
     }
 
-    sp<Aidl::IVibrator> aidlHal = waitForVintfService<Aidl::IVibrator>();
+    char propStr[PROP_VALUE_MAX] = {0};
+    sp<Aidl::IVibrator> aidlHal = nullptr;
+    property_get("sys.haptic.motor", propStr, "");
+    if (!strcmp(propStr, "linear") || !strcmp(propStr, "zlinear")){
+        aidlHal = waitForVintfService<Aidl::IVibrator>(String16("vibratorfeature"));
+        ALOGE("Connected to Vibrator HAL AIDL service : vibratorfeature");
+    } else{
+        aidlHal = waitForVintfService<Aidl::IVibrator>();
+        ALOGE("Connected to Vibrator HAL AIDL service : IVibrator");
+    }
     if (aidlHal) {
         ALOGV("Successfully connected to Vibrator HAL AIDL service.");
         return std::make_shared<AidlHalWrapper>(std::move(scheduler), aidlHal);

--- a/services/vibratorservice/include/vibratorservice/VibratorHalWrapper.h
+++ b/services/vibratorservice/include/vibratorservice/VibratorHalWrapper.h
@@ -22,6 +22,7 @@
 #include <android/hardware/vibrator/BnVibratorCallback.h>
 #include <android/hardware/vibrator/IVibrator.h>
 #include <binder/IServiceManager.h>
+#include <cutils/properties.h>
 
 #include <vibratorservice/VibratorCallbackScheduler.h>
 
@@ -331,8 +332,15 @@ public:
             std::shared_ptr<CallbackScheduler> scheduler, sp<hardware::vibrator::IVibrator> handle,
             std::function<HalResult<sp<hardware::vibrator::IVibrator>>()> reconnectFn =
                     []() {
-                        return HalResult<sp<hardware::vibrator::IVibrator>>::ok(
-                                checkVintfService<hardware::vibrator::IVibrator>());
+                        char propStr[PROP_VALUE_MAX] = {0};
+                        property_get("sys.haptic.motor", propStr, "");
+                        if (!strcmp(propStr, "linear") || !strcmp(propStr, "zlinear")){
+                            return HalResult<sp<hardware::vibrator::IVibrator>>::ok(
+                                    checkVintfService<hardware::vibrator::IVibrator>(String16("vibratorfeature")));
+                        } else{
+                            return HalResult<sp<hardware::vibrator::IVibrator>>::ok(
+                                    checkVintfService<hardware::vibrator::IVibrator>());
+                        }
                     })
           : HalWrapper(std::move(scheduler)),
             mReconnectFn(reconnectFn),


### PR DESCRIPTION
Small info:
To make vibratorfetature work it requires to set sys.haptic.motor prop, import all related props from Miui according to VibratorFeature, and engine itself including RichTap

You can check references in alioth DT and sm8250: https://github.com/SuperiorOS-Devices

- If vibratorfeature and props not found - it will fallback to usual AOSP Vibrator Hal, so it's perfect solution for this usecase

Change-Id: Ib32eb30d9e65938420ce2e6ee49db503f75bf9ac